### PR TITLE
Add Forgejo in the list of forges in 03 chapter

### DIFF
--- a/03-git-github-and-markdown/COURSE_MATERIAL.md
+++ b/03-git-github-and-markdown/COURSE_MATERIAL.md
@@ -319,7 +319,7 @@ _Alternatives are here for general knowledge. No need to learn them._
 - [GitLab](https://gitlab.com/) - My personal favorite
 - [Bitbucket](https://bitbucket.org/) - My least favorite
 - [Gitea](https://gitea.io/) - Very good self-hosted alternative
-- [Forgejo](https://forgejo.org/) - A community owned soft fork of Gitea with upcoming support of *[forge federations](https://forgefed.org/) (see more with the [ForgeFriends project](https://forgefriends.org/))*.
+- [Forgejo](https://forgejo.org/) - A community owned soft fork of Gitea with upcoming support of [forge federations](https://forgefed.org/) (see more with the [ForgeFriends project](https://forgefriends.org/)).
 - [Gogs](https://gogs.io/)
 
 _Missing item in the list? Feel free to open a pull request to add it! ✨_

--- a/03-git-github-and-markdown/COURSE_MATERIAL.md
+++ b/03-git-github-and-markdown/COURSE_MATERIAL.md
@@ -319,6 +319,7 @@ _Alternatives are here for general knowledge. No need to learn them._
 - [GitLab](https://gitlab.com/) - My personal favorite
 - [Bitbucket](https://bitbucket.org/) - My least favorite
 - [Gitea](https://gitea.io/) - Very good self-hosted alternative
+- [Forgejo](https://forgejo.org/) - A community owned soft fork of Gitea with upcoming support of *[forge federations](https://forgefed.org/) (see more with the [ForgeFriends project](https://forgefriends.org/))*.
 - [Gogs](https://gogs.io/)
 
 _Missing item in the list? Feel free to open a pull request to add it! ✨_


### PR DESCRIPTION
I thought it's a good idea to include Forgejo, as forge federation is in development since more than a year now and has the potential to be a strong concurrent to the GitHub monopoly in the future.

I personally manage most of my free software projects on [codeberg.org](https://codeberg.org/samuelroland/) (a Forgejo server) for these reasons.